### PR TITLE
Port 1.15.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -9,10 +9,10 @@ mod_internalid="${mod_id}"
 
 /// Versions
 mc_mappings_channel="snapshot"
-mc_mappings_version="20200119-1.14.4"
-forge_version="28.2.4"
-forge_loader_version="28"
-mc_version="1.14.4"
+mc_mappings_version="20200606-1.15.1"
+forge_version="31.2.0"
+forge_loader_version="31"
+mc_version="1.15.2"
 version="2.3.0"
 
 /// For @Mod, etc.

--- a/src/main/java/com/wumple/cannycomposter/ConfigManager.java
+++ b/src/main/java/com/wumple/cannycomposter/ConfigManager.java
@@ -106,7 +106,7 @@ public class ConfigManager
 	}
 
 	@SubscribeEvent
-	public static void onReload(final ModConfig.ConfigReloading configEvent)
+	public static void onReload(final ModConfig.Reloading configEvent)
 	{
 	}
 

--- a/src/main/java/com/wumple/cannycomposter/things/CannyComposterBlock.java
+++ b/src/main/java/com/wumple/cannycomposter/things/CannyComposterBlock.java
@@ -112,7 +112,7 @@ public class CannyComposterBlock extends XComposterBlock
 	}
 	
 	@Override
-	public void tick(BlockState state, World worldIn, BlockPos pos, Random random)
+	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random random)
 	{
 		if (!worldIn.isRemote())
 		{

--- a/update.json
+++ b/update.json
@@ -1,10 +1,15 @@
 {
   "homepage": "https://github.com/Stormwind99/CannyComposter",
   "promos": {
+    "1.15.2-latest": "2.3.0",
+    "1.15.2-recommended": "2.3.0",
     "1.14.4-latest": "2.3.0",
     "1.14.4-recommended": "2.3.0",
     "1.12.2-latest": "1.9.2",
     "1.12.2-recommended": "1.9.2"
+  },
+  "1.15.2": {
+    "2.3.0": "Added special $food nameKey to catch all food items if not specifically listed"
   },
   "1.14.4": {
     "2.3.0": "Added special $food nameKey to catch all food items if not specifically listed",


### PR DESCRIPTION
Depends on a 1.15.2 build of wumpleutil:3.6.0:
`compile fg.deobf('com.wumple.util:wumpleutil:3.6.0')`